### PR TITLE
fixed the tbai_rl package build issue

### DIFF
--- a/tbai_gridmap/CMakeLists.txt
+++ b/tbai_gridmap/CMakeLists.txt
@@ -15,7 +15,7 @@ find_package(OpenCV REQUIRED)
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES tbai_gridmap 
- CATKIN_DEPENDS  
+ CATKIN_DEPENDS  grid_map_ros grid_map_core
  DEPENDS OpenCV
 )
 


### PR DESCRIPTION
Hi @lnotspotl ,
I followed the given build instructions. I had following problem while build tbai_rl package as shown in figure.

![issue_with_grid_map](https://github.com/user-attachments/assets/913ac9a6-bd2d-4aae-941f-5d36bba74e66)

I fixed the issue in this pull request. I think the main issue is with building tbai_rl, the build system can't access the headers of the grid_map_ros and grid_map_core while building this package.  

I fixed this problem by changing the tbai_gridmap package cmakelist file from

```cmake
catkin_package(
  INCLUDE_DIRS include
  LIBRARIES tbai_gridmap 
 CATKIN_DEPENDS  
 DEPENDS OpenCV
)
```

to 

```cmake
catkin_package(
  INCLUDE_DIRS include
  LIBRARIES tbai_gridmap 
 CATKIN_DEPENDS  grid_map_ros grid_map_core
 DEPENDS OpenCV
)
```
let me know if you need any further information from my side. Thank you