### PR TITLE
control the robot using keyboard

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -25,3 +25,6 @@
 [submodule "dependencies/elevation_mapping_cupy"]
 	path = dependencies/elevation_mapping_cupy
 	url = git@github.com:lnotspotl/elevation_mapping_cupy.git
+[submodule "dependencies/teleop_twist_keyboard"]
+	path = dependencies/teleop_twist_keyboard
+	url = https://github.com/ros-teleop/teleop_twist_keyboard.git

--- a/tbai_mpc_blind/config/default_config.yaml
+++ b/tbai_mpc_blind/config/default_config.yaml
@@ -38,7 +38,7 @@ anymal_d:
       joints: *jn
 
 reference_generator:
-  type: "twist"
+  type: "joy" #change it to 'twist' to control with keyboard
 
   joystick:
     topic: "joy"

--- a/tbai_mpc_blind/config/default_config.yaml
+++ b/tbai_mpc_blind/config/default_config.yaml
@@ -38,7 +38,7 @@ anymal_d:
       joints: *jn
 
 reference_generator:
-  type: "joystick"
+  type: "twist"
 
   joystick:
     topic: "joy"

--- a/tbai_mpc_blind/launch/simple.launch
+++ b/tbai_mpc_blind/launch/simple.launch
@@ -6,7 +6,8 @@
     <arg name="tbai_config_path"    default="$(find tbai_mpc_blind)/config/default_config.yaml"/>
     <arg name="description_name"    default="robot_description"/>
     <arg name="description_file"    default="$(find tbai_description)/urdf/anymal_d_gazebo.urdf.xacro"/>
-    <arg name="input"               default="true"/>
+    <!-- true if you want to control the robot with joystick/ false to control with keyboard -->
+    <arg name="joystick"               default="true"/> 
 
     <arg name="sqp_settings_file" default="$(find tbai_mpc_blind)/config/sqp.info"/>
     <arg name="frame_declaration_file" default="$(find tbai_mpc_blind)/config/frame_declarations.info"/>
@@ -23,10 +24,13 @@
     <arg name="z" default="3.0"/>
 
     <!-- Joystick node -->
-    <arg name="joystick_dev" default="/dev/input/js0"/>
-    <node unless="$(arg input)" name="joy_node" pkg="joy" type="joy_node" output="screen">
+    <arg if="$(arg joystick)" name="joystick_dev" default="/dev/input/js0"/>
+    <node if="$(arg joystick)" name="joy_node" pkg="joy" type="joy_node" output="screen">
         <param name="dev" value="$(arg joystick_dev)"/>
     </node>
+    <node unless="$(arg joystick)" name="teleop_twist_keyboard" pkg="teleop_twist_keyboard" type="teleop_twist_keyboard.py" output="screen" launch-prefix="gnome-terminal --">
+    </node>
+
 
     <!-- Upload config path to ROS param server -->
     <param name="tbai_config_path" type="string" value="$(arg tbai_config_path)"/>

--- a/tbai_mpc_blind/launch/simple.launch
+++ b/tbai_mpc_blind/launch/simple.launch
@@ -6,6 +6,7 @@
     <arg name="tbai_config_path"    default="$(find tbai_mpc_blind)/config/default_config.yaml"/>
     <arg name="description_name"    default="robot_description"/>
     <arg name="description_file"    default="$(find tbai_description)/urdf/anymal_d_gazebo.urdf.xacro"/>
+    <arg name="input"               default="true"/>
 
     <arg name="sqp_settings_file" default="$(find tbai_mpc_blind)/config/sqp.info"/>
     <arg name="frame_declaration_file" default="$(find tbai_mpc_blind)/config/frame_declarations.info"/>
@@ -23,7 +24,7 @@
 
     <!-- Joystick node -->
     <arg name="joystick_dev" default="/dev/input/js0"/>
-    <node name="joy_node" pkg="joy" type="joy_node" output="screen">
+    <node unless="$(arg input)" name="joy_node" pkg="joy" type="joy_node" output="screen">
         <param name="dev" value="$(arg joystick_dev)"/>
     </node>
 

--- a/tbai_mpc_blind/package.xml
+++ b/tbai_mpc_blind/package.xml
@@ -14,6 +14,7 @@
   <depend>tbai_core</depend>
   <depend>tbai_msgs</depend>
   <depend>tbai_static</depend>
+  <depend>teleop_twist_keyboard</depend>
 
   <export>
   </export>


### PR DESCRIPTION
Hi @lnotspotl ,
I added the keyboard control using the teleop_twist_keyboard [package](https://github.com/ros-teleop/teleop_twist_keyboard.git). Currently, I did the necessary changes to control the robot using keyboard  in mpc blind mode. You can have a look at it and let me know your suggestions and comments. If you are happy with my current changes, I will extend it to remaining controllers.
you need to do the following steps
1) I have already added teleop_twist_package as a dependent to mpc_blind package and also added it as git submodule. I think it should work without any issues. If it not working, you can download the package from [here](https://github.com/ros-teleop/teleop_twist_keyboard.git) 

2) change type to twist [here]( https://github.com/rua0ra1/tbai/blob/5f2e181333c485925f8a28eea810ed0d5392e51a/tbai_mpc_blind/config/default_config.yaml#L40) 
```
type: "joy" #change it to 'twist' to control with keyboard
```
3) change joystick argument to false [here](https://github.com/rua0ra1/tbai/blob/5f2e181333c485925f8a28eea810ed0d5392e51a/tbai_mpc_blind/launch/simple.launch#L10)
```
   <!-- true if you want to control the robot with joystick/ false to control with keyboard -->
    <arg name="joystick"               default="true"/> 
```